### PR TITLE
Added support for all of ElasticEmail's /email/send parameters

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -35,7 +35,7 @@ Here's the most direct way to get your work merged into the project:
 
 *   Austin Ziegler created bamboo\_elastic\_email, based in part on
     [bamboo\_sparkpost][] by Andrew Timberlake.
-*   Jonathan Principe upgraded to support Bamboo 1.0 and added postBack support
+*   Jonathan Principe upgraded to support Bamboo 1.0 and added support for all ElasticEmail send parameters
 
 [quality commit messages]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [Credo]: https://github.com/rrrene/credo

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ An [Elastic Email][] adapter for the [Bamboo][] email app for Elixir.
 
 4.  Follow the Bamboo [Getting Started Guide][getting_started].
 
-5.  To use [ElasticEmail's API parameters][email_send] you can place a value in
-    the `Email#private` parameter:
+5.  To use [Elastic Email's API parameters][email_send] that are not automatically
+      handled by this plug-in natively, you can place a value in the `Email#private`
+      parameter:
 
     ```elixir
     Email.put_private(email, :elastic_send_options, %{post_back: "your-post-back-value", pool_name: "your-pool-name"})

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ An [Elastic Email][] adapter for the [Bamboo][] email app for Elixir.
 
 4.  Follow the Bamboo [Getting Started Guide][getting_started].
 
-5.  To use [ElasticEmail's additional api params][email_send] you can place a value in
+5.  To use [ElasticEmail's API parameters][email_send] you can place a value in
     the `Email#private` parameter:
 
     ```elixir
-    Email.put_private(email, :elastic_custom_vars, %{post_back: "your-post-back-value", pool_name: "your-pool-name"})
+    Email.put_private(email, :elastic_send_options, %{post_back: "your-post-back-value", pool_name: "your-pool-name"})
     ```
 
     Supported parameters are:

--- a/README.md
+++ b/README.md
@@ -38,12 +38,30 @@ An [Elastic Email][] adapter for the [Bamboo][] email app for Elixir.
 
 4.  Follow the Bamboo [Getting Started Guide][getting_started].
 
-5.  To use ElasticEmail's [postBack][] functionality you can place a value in
+5.  To use [ElasticEmail's additional api params][email_send] you can place a value in
     the `Email#private` parameter:
 
     ```elixir
-    Email.put_private(email, :elastic_custom_vars, %{post_back: "your-post-back-value"})
+    Email.put_private(email, :elastic_custom_vars, %{post_back: "your-post-back-value", pool_name: "your-pool-name"})
     ```
+
+    Supported parameters are:
+      * :attachments
+      * :channel
+      * :charset_body_html
+      * :charset_body_text
+      * :data_source
+      * :encoding_type
+      * :lists
+      * :merge
+      * :merge_source_filename
+      * :pool_name
+      * :post_back
+      * :segments
+      * :template
+      * :time_off_set_minutes
+      * :track_clicks
+      * :track_opens
 
 ## Community and Contributing
 
@@ -60,4 +78,4 @@ Kinetic Cafe [open source projects][], is under the Kinetic Cafe Open Source
 [Contributing.md]: Contributing.md
 [open source projects]: https://github.com/KineticCafe
 [kccoc]: https://github.com/KineticCafe/code-of-conduct
-[postBack]: https://api.elasticemail.com/public/help#Email_Send
+[email_send]: https://api.elasticemail.com/public/help#Email_Send

--- a/lib/bamboo/adapters/elastic_email_adapter.ex
+++ b/lib/bamboo/adapters/elastic_email_adapter.ex
@@ -209,7 +209,7 @@ defmodule Bamboo.ElasticEmailAdapter do
   defp put_elastic_send_options(%{private: %{elastic_send_options: options}} = email) do
     options
     |> Enum.map(&send_option/1)
-    |> Enum.reject(&is_nil/1)
+    |> Enum.reject(&is_nil(&1) || match?({_, nil}, &1))
     |> Enum.into(email)
   end
 

--- a/lib/bamboo/adapters/elastic_email_adapter.ex
+++ b/lib/bamboo/adapters/elastic_email_adapter.ex
@@ -145,7 +145,7 @@ defmodule Bamboo.ElasticEmailAdapter do
     |> put_charset()
     |> put_headers(email)
     |> put_api_key(api_key)
-    |> put_post_back()
+    |> put_custom_vars()
     |> put_transactional()
     |> transform_fields()
     |> filter_fields()
@@ -197,10 +197,42 @@ defmodule Bamboo.ElasticEmailAdapter do
 
   defp put_transactional(map), do: Map.put(map, "isTransactional", true)
 
-  defp put_post_back(%{private: %{elastic_custom_vars: %{post_back: post_back}}} = map),
-    do: Map.put(map, "postBack", post_back)
+  defp put_custom_vars(%{private: %{elastic_custom_vars: custom_vars}} = map) do
+    custom_vars
+    |> Enum.map(&custom_var(&1))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reduce(%{}, fn var, acc -> Map.merge(acc, var) end)
+    |> Map.merge(map)
+  end
 
-  defp put_post_back(map), do: map
+  defp put_custom_vars(map), do: map
+
+  defp custom_var({:attachments, attachments}), do: %{"attachments" => attachments}
+  defp custom_var({:channel, channel}), do: %{"channel" => channel}
+  defp custom_var({:data_source, data_source}), do: %{"dataSource" => data_source}
+  defp custom_var({:encoding_type, encoding_type}), do: %{"encodingType" => encoding_type}
+  defp custom_var({:lists, lists}), do: %{"lists" => lists}
+  defp custom_var({:merge, merge}), do: %{"merge" => merge}
+  defp custom_var({:pool_name, pool_name}), do: %{"poolName" => pool_name}
+  defp custom_var({:post_back, post_back}), do: %{"postBack" => post_back}
+  defp custom_var({:segments, segments}), do: %{"segments" => segments}
+  defp custom_var({:template, template}), do: %{"template" => template}
+  defp custom_var({:track_clicks, track_clicks}), do: %{"trackClicks" => track_clicks}
+  defp custom_var({:track_opens, track_opens}), do: %{"trackOpens" => track_opens}
+
+  defp custom_var({:charset_body_html, charset_body_html}),
+    do: %{"charsetBodyHtml" => charset_body_html}
+
+  defp custom_var({:charset_body_text, charset_body_text}),
+    do: %{"charsetBodyText" => charset_body_text}
+
+  defp custom_var({:merge_source_filename, merge_source_filename}),
+    do: %{"mergeSourceFilename" => merge_source_filename}
+
+  defp custom_var({:time_off_set_minutes, time_off_set_minutes}),
+    do: %{"timeOffSetMinutes" => time_off_set_minutes}
+
+  defp custom_var(_), do: nil
 
   defp put_headers(body, %Email{headers: headers}) do
     Enum.reduce(headers, body, fn {key, value}, acc ->
@@ -222,20 +254,35 @@ defmodule Bamboo.ElasticEmailAdapter do
   defp combine_name_and_email({name, email}), do: "#{name} <#{email}>"
 
   @message_fields [
+    :apikey,
+    :attachments,
+    :bodyHtml,
+    :bodyText,
+    :channel,
+    :charset,
+    :charsetBodyHtml,
+    :charsetBodyText,
+    :dataSource,
+    :encodingType,
     :from,
     :fromName,
+    :isTransactional,
+    :lists,
+    :merge,
+    :mergeSourceFilename,
     :msgTo,
     :msgCc,
     :msgBcc,
-    :subject,
-    :bodyHtml,
-    :bodyText,
-    :apikey,
-    :charset,
-    :isTransactional,
+    :poolName,
     :postBack,
     :replyTo,
-    :replyToName
+    :replyToName,
+    :segments,
+    :subject,
+    :template,
+    :timeOffSetMinutes,
+    :trackClicks,
+    :trackOpens
   ]
 
   @message_fields ~w(subject)a

--- a/test/bamboo/adapters/elastic_email_adapter_test.exs
+++ b/test/bamboo/adapters/elastic_email_adapter_test.exs
@@ -160,9 +160,9 @@ defmodule Bamboo.ElasticEmailAdapterTest do
       end
     end
 
-    test "deliver/2 adds custom elastic fields from email to the message" do
+    test "deliver/2 adds custom elastic fields using from email to the message" do
       email =
-        Email.put_private(new_email(), :elastic_custom_vars, %{
+        Email.put_private(new_email(), :elastic_send_options, %{
           post_back: "12345",
           pool_name: "test"
         })
@@ -177,7 +177,7 @@ defmodule Bamboo.ElasticEmailAdapterTest do
 
     test "deliver/2 skips unknown custom elastic fields from email to the message" do
       email =
-        Email.put_private(new_email(), :elastic_custom_vars, %{
+        Email.put_private(new_email(), :elastic_send_options, %{
           pool_name: "test",
           unknown: "unknown"
         })
@@ -188,6 +188,21 @@ defmodule Bamboo.ElasticEmailAdapterTest do
 
       assert params["poolName"] == "test"
       refute params["unknown"]
+    end
+
+    test "deliver/2 adds custom elastic fields using deprecated :elastic_custom_vars" do
+      email =
+        Email.put_private(new_email(), :elastic_custom_vars, %{
+          post_back: "12345",
+          pool_name: "test"
+        })
+
+      ElasticEmailAdapter.deliver(email, @config)
+
+      assert_receive {:fake_elastic_email, %{params: params}}
+
+      assert params["postBack"] == "12345"
+      assert params["poolName"] == "test"
     end
 
     defp new_email(attrs \\ []) do

--- a/test/bamboo/adapters/elastic_email_adapter_test.exs
+++ b/test/bamboo/adapters/elastic_email_adapter_test.exs
@@ -190,6 +190,21 @@ defmodule Bamboo.ElasticEmailAdapterTest do
       refute params["unknown"]
     end
 
+    test "deliver/2 rejects custom elastic fields with nil value" do
+      email =
+        Email.put_private(new_email(), :elastic_send_options, %{
+          post_back: "12345",
+          pool_name: nil
+        })
+
+      ElasticEmailAdapter.deliver(email, @config)
+
+      assert_receive {:fake_elastic_email, %{params: params}}
+
+      assert params["postBack"] == "12345"
+      refute params["poolName"]
+    end
+
     test "deliver/2 adds custom elastic fields using deprecated :elastic_custom_vars" do
       email =
         Email.put_private(new_email(), :elastic_custom_vars, %{

--- a/test/bamboo/adapters/elastic_email_adapter_test.exs
+++ b/test/bamboo/adapters/elastic_email_adapter_test.exs
@@ -161,13 +161,33 @@ defmodule Bamboo.ElasticEmailAdapterTest do
     end
 
     test "deliver/2 adds custom elastic fields from email to the message" do
-      email = Email.put_private(new_email(), :elastic_custom_vars, %{post_back: "12345"})
+      email =
+        Email.put_private(new_email(), :elastic_custom_vars, %{
+          post_back: "12345",
+          pool_name: "test"
+        })
 
       ElasticEmailAdapter.deliver(email, @config)
 
       assert_receive {:fake_elastic_email, %{params: params}}
 
       assert params["postBack"] == "12345"
+      assert params["poolName"] == "test"
+    end
+
+    test "deliver/2 skips unknown custom elastic fields from email to the message" do
+      email =
+        Email.put_private(new_email(), :elastic_custom_vars, %{
+          pool_name: "test",
+          unknown: "unknown"
+        })
+
+      ElasticEmailAdapter.deliver(email, @config)
+
+      assert_receive {:fake_elastic_email, %{params: params}}
+
+      assert params["poolName"] == "test"
+      refute params["unknown"]
     end
 
     defp new_email(attrs \\ []) do


### PR DESCRIPTION
Leveraged the `bamboo` `put_private` method and the custom var `elastic_send_options` in `bamboo_elastic_email` to pass the full list of parameters supported by ElasticEmail's /email/send endpoint: https://api.elasticemail.com/public/help#Email_Send